### PR TITLE
Adding Functor and Applicative Instances To EqParser

### DIFF
--- a/Math/Diophantine/Grammar.y
+++ b/Math/Diophantine/Grammar.y
@@ -95,6 +95,15 @@ instance Show ParseError where
     show PowerOutOfBounds = "Power out of bounds"
     show BadGrammar       = "Bad equation grammar"
 
+-- | Functor instance for the parser 
+instance Functor EqParser where
+    fmap f (Valid a)    = Valid (f a)
+    fmap f (Invalid pe) = (Invalid pe)
+
+-- | Applicative functor instance for the parser
+instance Applicative EqParser where
+    pure t              = Valid t
+    (<*>)               = ap
 
 -- | Monad instance for the parser.
 instance Monad EqParser where


### PR DESCRIPTION
All Monad instances must also have Functor and Applicative instances, per
https://gitlab.haskell.org/ghc/ghc/wikis/migration/7.10#ghc-says-no-instance-for-applicative-.
This commit adds those instances for the EqParser.